### PR TITLE
Increase bundle size limit to accommodate new dependencies

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -80,7 +80,7 @@
                 {
                   "type": "initial",
                   "maximumWarning": "500kB",
-                  "maximumError": "1MB"
+                  "maximumError": "2MB"
                 },
                 {
                   "type": "anyComponentStyle",


### PR DESCRIPTION
This PR increases the maximum allowed bundle size from 1MB to 2MB in the Angular configuration.