### PR TITLE
Rename project from busbox-ui to busbox-mini-app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN mkdir /etc/nginx/logs && \
 FROM nginx:alpine
 
 # Copy built files from the build stage
-COPY --from=builder /app/dist/busbox-ui /usr/share/nginx/html
+COPY --from=builder /app/dist/busbox-mini-app /usr/share/nginx/html
 
 # Copy Nginx configuration
 COPY --from=nginx-config /etc/nginx/nginx.conf /etc/nginx/nginx.conf

--- a/README.en.md
+++ b/README.en.md
@@ -41,7 +41,7 @@ The project can be run both locally and through Docker. Deployment is implemente
 ### 1. Locally
 
 - Clone the project to your computer:
-  - `https://github.com/buscourier/busbox-ui.git`
+  - `https://github.com/buscourier/busbox-mini-app.git`
 - Navigate to the project and install dependencies:
   - `npm ci`
 - Activate the `develop` branch in the project:

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
 ### 1. Локально
 
 - Склонировать проект на свой компьютер:
-  - `https://github.com/buscourier/busbox-ui.git`
+  - `https://github.com/buscourier/busbox-mini-app.git`
 - Перейти в проект и установить зависимости:
   - `npm ci`
 - В проекте активировать ветку `develop`:

--- a/angular.json
+++ b/angular.json
@@ -3,7 +3,7 @@
   "version": 1,
   "newProjectRoot": "projects",
   "projects": {
-    "busbox-ui": {
+    "busbox-mini-app": {
       "projectType": "application",
       "schematics": {
         "@schematics/angular:component": {
@@ -20,7 +20,7 @@
             "customWebpackConfig": {
               "path": "./custom-webpack.config.js"
             },
-            "outputPath": "dist/busbox-ui",
+            "outputPath": "dist/busbox-mini-app",
             "index": "src/index.html",
             "main": "src/main.ts",
             "polyfills": [
@@ -114,17 +114,17 @@
         "serve": {
           "builder": "@angular-builders/custom-webpack:dev-server",
           "options": {
-            "buildTarget": "busbox-ui:build"
+            "buildTarget": "busbox-mini-app:build"
           },
           "configurations": {
             "production": {
-              "buildTarget": "busbox-ui:build:production"
+              "buildTarget": "busbox-mini-app:build:production"
             },
             "development": {
-              "buildTarget": "busbox-ui:build:development"
+              "buildTarget": "busbox-mini-app:build:development"
             },
             "staging": {
-              "buildTarget": "busbox-ui:build:staging"
+              "buildTarget": "busbox-mini-app:build:staging"
             }
           },
           "defaultConfiguration": "development"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "busbox-ui",
+  "name": "busbox-mini-app",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "busbox-ui",
+      "name": "busbox-mini-app",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "busbox-ui",
+  "name": "busbox-mini-app",
   "version": "1.0.0",
   "description": "Starter template for Angular project with NgRx and Tailwind CSS",
   "author": "Anton Maiatskii <work.mayatskiy@gmail.com>",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/buscourier/busbox-ui"
+    "url": "https://github.com/buscourier/busbox-mini-app"
   },
   "keywords": [
     "angular",
@@ -14,9 +14,9 @@
     "ngrx",
     "tailwind"
   ],
-  "homepage": "https://busbox-ui.dev",
+  "homepage": "https://busbox-mini-app.dev",
   "bugs": {
-    "url": "https://github.com/buscourier/busbox-ui/issues"
+    "url": "https://github.com/buscourier/busbox-mini-app/issues"
   },
   "engines": {
     "node": ">=20.15.0"


### PR DESCRIPTION
This PR implements a complete project renaming from "busbox-ui" to "busbox-mini-app" to better reflect the application's purpose as a mini-application rather than a general UI project.

The changes include:

Updated project name in all npm configuration files (package.json, package-lock.json)
Modified Angular build configuration (angular.json) with new project identifier and build targets
Changed output directory path to dist/busbox-mini-app
Updated Docker deployment configuration in Dockerfile
Fixed repository URLs and references in both English and Russian README files
Updated homepage and issues URLs in package.json